### PR TITLE
Update license link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ For details on how to use Vercel, check out our [documentation](https://vercel.c
 
 - [Code of Conduct](./.github/CODE_OF_CONDUCT.md)
 - [Contributing Guidelines](./.github/CONTRIBUTING.md)
-- [MIT License](./LICENSE)
+- [Apache 2.0 License](./LICENSE)


### PR DESCRIPTION
this commit fixed half the MIT references but left the README one https://github.com/vercel/vercel/commit/001f2f60b8ddcd01699d2aeb96fc98ba077b780e

### Related Issues

None

### 📋 Checklist

#### Tests

- [x] The code changed/added as part of this PR has been covered with tests
- [x] All tests pass locally with `yarn test-unit`

#### Code Review

- [ ] This PR has a concise title and thorough description useful to a reviewer
- [ ] Issue from task tracker has a link to this PR
